### PR TITLE
Mingw compilation port

### DIFF
--- a/makefile.mingw
+++ b/makefile.mingw
@@ -1,0 +1,9 @@
+all:
+	mkdir -p win32/bin
+	cd win32/librpc && make -f makefile.mingw
+	cd win32/rpcgen && make -f makefile.mingw
+	cd win32/rpcinfo && make -f makefile.mingw
+	cd win32/service && make -f makefile.mingw
+
+clean:
+	rm -f win32/*/*.o win32/*/*.exe win32/*/*.dll win32/*/*.lib

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -1,9 +1,25 @@
-all:
-	mkdir -p win32/bin
-	cd win32/librpc && make -f makefile.mingw
-	cd win32/rpcgen && make -f makefile.mingw
-	cd win32/rpcinfo && make -f makefile.mingw
-	cd win32/service && make -f makefile.mingw
+MINGW32=i686-w64-mingw32
+MINGW64=x86_64-w64-mingw32
 
+all:	32 64
+
+32:
+	mkdir -p win32/bin
+	mkdir -p win32/bin32
+	cd win32/librpc && MINGW=$(MINGW32) make -f makefile.mingw
+	cd win32/rpcgen && MINGW=$(MINGW32) make -f makefile.mingw
+	cd win32/rpcinfo && MINGW=$(MINGW32) make -f makefile.mingw
+	cd win32/service && MINGW=$(MINGW32) make -f makefile.mingw
+	cp win32/bin/* win32/bin32
+
+64:
+	mkdir -p win32/bin
+	mkdir -p win32/bin64
+	cd win32/librpc && MINGW=$(MINGW64) make -f makefile.mingw
+	cd win32/rpcgen && MINGW=$(MINGW64) make -f makefile.mingw
+	cd win32/rpcinfo && MINGW=$(MINGW64) make -f makefile.mingw
+	cd win32/service && MINGW=$(MINGW64) make -f makefile.mingw
+	cp win32/bin/* win32/bin64
+	
 clean:
-	rm -f win32/*/*.o win32/*/*.exe win32/*/*.dll win32/*/*.lib
+	rm -f win32/*/*.o win32/*/*.exe win32/*/*.dll win32/*/*.lib bin/* bin32/* bin64/*

--- a/win32/include/rpc/Pmap_rmt.h
+++ b/win32/include/rpc/Pmap_rmt.h
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * ONC RPC for WIN32.
+ * 1997 by WD Klotz
+ * ESRF, BP 220, F-38640 Grenoble, CEDEX
+ * klotz-tech@esrf.fr
+ *
+ * SUN's ONC RPC for Windows NT and Windows 95. Ammended port from
+ * Martin F.Gergeleit's distribution. This version has been modified
+ * and cleaned, such as to be compatible with Windows NT and Windows 95. 
+ * Compiler: MSVC++ version 4.2 and 5.0.
+ *
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ **********************************************************************/
+/*********************************************************************
+ * RPC for the Windows NT Operating System
+ * 1993 by Martin F. Gergeleit
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ *
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ *********************************************************************/
+
+/* @(#)pmap_rmt.h	2.1 88/07/29 4.0 RPCSRC; from 1.2 88/02/08 SMI */
+/*
+ * Sun RPC is a product of Sun Microsystems, Inc. and is provided for
+ * unrestricted use provided that this legend is included on all tape
+ * media and as a part of the software program in whole or part.  Users
+ * may copy or modify Sun RPC without charge, but are not authorized
+ * to license or distribute it to anyone else except as part of a product or
+ * program developed by the user.
+ * 
+ * SUN RPC IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING THE
+ * WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
+ * 
+ * Sun RPC is provided with no support and without any obligation on the
+ * part of Sun Microsystems, Inc. to assist in its use, correction,
+ * modification or enhancement.
+ * 
+ * SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
+ * INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY SUN RPC
+ * OR ANY PART THEREOF.
+ * 
+ * In no event will Sun Microsystems, Inc. be liable for any lost revenue
+ * or profits or other special, indirect and consequential damages, even if
+ * Sun has been advised of the possibility of such damages.
+ * 
+ * Sun Microsystems, Inc.
+ * 2550 Garcia Avenue
+ * Mountain View, California  94043
+ */
+
+/*
+ * Structures and XDR routines for parameters to and replies from
+ * the portmapper remote-call-service.
+ *
+ * Copyright (C) 1986, Sun Microsystems, Inc.
+ */
+#ifndef __PMAP_RMT_HEADER__
+#define __PMAP_RMT_HEADER__
+
+#include <rpc/types.h>
+
+struct rmtcallargs {
+	u_long prog, vers, proc, arglen;
+	caddr_t args_ptr;
+	xdrproc_t xdr_args;
+};
+
+ONCRPCAPI bool_t xdr_rmtcall_args();
+
+struct rmtcallres {
+	u_long *port_ptr;
+	u_long resultslen;
+	caddr_t results_ptr;
+	xdrproc_t xdr_results;
+};
+
+ONCRPCAPI bool_t xdr_rmtcallres();
+
+#endif //__PMAP_RMT_HEADER__

--- a/win32/include/rpc/netdb.h
+++ b/win32/include/rpc/netdb.h
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * ONC RPC for WIN32.
+ * 1997 by WD Klotz
+ * ESRF, BP 220, F-38640 Grenoble, CEDEX
+ * klotz-tech@esrf.fr
+ *
+ * SUN's ONC RPC for Windows NT and Windows 95. Ammended port from
+ * Martin F.Gergeleit's distribution. This version has been modified
+ * and cleaned, such as to be compatible with Windows NT and Windows 95. 
+ * Compiler: MSVC++ version 4.2 and 5.0.
+ *
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ **********************************************************************/
+/*********************************************************************
+ * RPC for the Windows NT Operating System
+ * 1993 by Martin F. Gergeleit
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ *
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ *********************************************************************/
+
+/* @(#)netdb.h	2.1 88/07/29 3.9 RPCSRC */
+/*
+ * Sun RPC is a product of Sun Microsystems, Inc. and is provided for
+ * unrestricted use provided that this legend is included on all tape
+ * media and as a part of the software program in whole or part.  Users
+ * may copy or modify Sun RPC without charge, but are not authorized
+ * to license or distribute it to anyone else except as part of a product or
+ * program developed by the user.
+ * 
+ * SUN RPC IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING THE
+ * WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
+ * 
+ * Sun RPC is provided with no support and without any obligation on the
+ * part of Sun Microsystems, Inc. to assist in its use, correction,
+ * modification or enhancement.
+ *
+ * SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
+ * INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY SUN RPC
+ * OR ANY PART THEREOF.
+ * 
+ * In no event will Sun Microsystems, Inc. be liable for any lost revenue
+ * or profits or other special, indirect and consequential damages, even if
+ * Sun has been advised of the possibility of such damages.
+ * 
+ * Sun Microsystems, Inc.
+ * 2550 Garcia Avenue
+ * Mountain View, California  94043
+ */
+/*	@(#)rpc.h 1.8 87/07/24 SMI	*/
+
+#ifndef __NETDB_HEADER__
+#define __NETDB_HEADER__
+/* Really belongs in <netdb.h> */
+#include <rpc/types.h>
+
+#if !defined(_STRUCT_RPCENT)
+struct rpcent {
+      char    *r_name;        /* name of server for this rpc program */
+      char    **r_aliases;    /* alias list */
+      int     r_number;       /* rpc program number */
+};
+#define _STRUCT_RPCENT 1
+#endif /* _STRUCT_RPCENT */
+
+ONCRPCAPI struct rpcent *getrpcbyname();
+ONCRPCAPI struct rpcent *getrpcbynumber();
+ONCRPCAPI struct rpcent *getrpcent();
+
+#endif //__NETDB_HEADER__

--- a/win32/include/rpc/pmap_cln.h
+++ b/win32/include/rpc/pmap_cln.h
@@ -1,0 +1,111 @@
+/**********************************************************************
+ * ONC RPC for WIN32.
+ * 1997 by WD Klotz
+ * ESRF, BP 220, F-38640 Grenoble, CEDEX
+ * klotz-tech@esrf.fr
+ *
+ * SUN's ONC RPC for Windows NT and Windows 95. Ammended port from
+ * Martin F.Gergeleit's distribution. This version has been modified
+ * and cleaned, such as to be compatible with Windows NT and Windows 95. 
+ * Compiler: MSVC++ version 4.2 and 5.0.
+ *
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ **********************************************************************/
+/*********************************************************************
+ * RPC for the Windows NT Operating System
+ * 1993 by Martin F. Gergeleit
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ *
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ *********************************************************************/
+
+/* @(#)pmap_clnt.h	2.1 88/07/29 4.0 RPCSRC; from 1.11 88/02/08 SMI */
+/*
+ * Sun RPC is a product of Sun Microsystems, Inc. and is provided for
+ * unrestricted use provided that this legend is included on all tape
+ * media and as a part of the software program in whole or part.  Users
+ * may copy or modify Sun RPC without charge, but are not authorized
+ * to license or distribute it to anyone else except as part of a product or
+ * program developed by the user.
+ * 
+ * SUN RPC IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING THE
+ * WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
+ * 
+ * Sun RPC is provided with no support and without any obligation on the
+ * part of Sun Microsystems, Inc. to assist in its use, correction,
+ * modification or enhancement.
+ * 
+ * SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
+ * INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY SUN RPC
+ * OR ANY PART THEREOF.
+ * 
+ * In no event will Sun Microsystems, Inc. be liable for any lost revenue
+ * or profits or other special, indirect and consequential damages, even if
+ * Sun has been advised of the possibility of such damages.
+ * 
+ * Sun Microsystems, Inc.
+ * 2550 Garcia Avenue
+ * Mountain View, California  94043
+ */
+
+/*
+ * pmap_clnt.h
+ * Supplies C routines to get to portmap services.
+ *
+ * Copyright (C) 1984, Sun Microsystems, Inc.
+ */
+
+/*
+ * Usage:
+ *	success = pmap_set(program, version, protocol, port);
+ *	success = pmap_unset(program, version);
+ *	port = pmap_getport(address, program, version, protocol);
+ *	head = pmap_getmaps(address);
+ *	clnt_stat = pmap_rmtcall(address, program, version, procedure,
+ *		xdrargs, argsp, xdrres, resp, tout, port_ptr)
+ *		(works for udp only.) 
+ * 	clnt_stat = clnt_broadcast(program, version, procedure,
+ *		xdrargs, argsp,	xdrres, resp, eachresult)
+ *		(like pmap_rmtcall, except the call is broadcasted to all
+ *		locally connected nets.  For each valid response received,
+ *		the procedure eachresult is called.  Its form is:
+ *	done = eachresult(resp, raddr)
+ *		bool_t done;
+ *		caddr_t resp;
+ *		struct sockaddr_in raddr;
+ *		where resp points to the results of the call and raddr is the
+ *		address if the responder to the broadcast.
+ */
+#ifndef __PMAP_CLN_HEADER__
+#define __PMAP_CLN_HEADER__
+#include <rpc/types.h>
+
+typedef bool_t (*resultproc_t)();
+
+ONCRPCAPI bool_t		pmap_set(u_long program, u_long version, int protocol,   u_short port);
+ONCRPCAPI bool_t		pmap_unset(u_long program,       u_long version);
+ONCRPCAPI struct pmaplist *pmap_getmaps(struct sockaddr_in *address);
+ONCRPCAPI enum clnt_stat pmap_rmtcall(struct sockaddr_in *addr,   u_long prog, u_long vers, u_long proc, xdrproc_t xdrargs,
+                                  caddr_t argsp, xdrproc_t xdrres, caddr_t resp, struct timeval tout,   u_long *port_ptr);
+ONCRPCAPI enum clnt_stat clnt_broadcast(
+        u_long          prog,           /* program number */
+        u_long          vers,           /* version number */
+        u_long          proc,           /* procedure number */
+        xdrproc_t       xargs,          /* xdr routine for args */
+        caddr_t         argsp,          /* pointer to args */
+        xdrproc_t       xresults,       /* xdr routine for results */
+        caddr_t         resultsp,       /* pointer to results */
+        resultproc_t    eachresult      /* call with each result obtained */
+  );
+
+ONCRPCAPI u_short pmap_getport(struct sockaddr_in *address,       u_long program, u_long version, u_int protocol);
+
+#endif //__PMAP_CLN_HEADER__

--- a/win32/include/rpc/pmap_pro.h
+++ b/win32/include/rpc/pmap_pro.h
@@ -1,0 +1,128 @@
+/**********************************************************************
+ * ONC RPC for WIN32.
+ * 1997 by WD Klotz
+ * ESRF, BP 220, F-38640 Grenoble, CEDEX
+ * klotz-tech@esrf.fr
+ *
+ * SUN's ONC RPC for Windows NT and Windows 95. Ammended port from
+ * Martin F.Gergeleit's distribution. This version has been modified
+ * and cleaned, such as to be compatible with Windows NT and Windows 95. 
+ * Compiler: MSVC++ version 4.2 and 5.0.
+ *
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ **********************************************************************/
+/*********************************************************************
+ * RPC for the Windows NT Operating System
+ * 1993 by Martin F. Gergeleit
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ *
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ *********************************************************************/
+
+/* @(#)pmap_prot.h	2.1 88/07/29 4.0 RPCSRC; from 1.14 88/02/08 SMI */
+/*
+ * Sun RPC is a product of Sun Microsystems, Inc. and is provided for
+ * unrestricted use provided that this legend is included on all tape
+ * media and as a part of the software program in whole or part.  Users
+ * may copy or modify Sun RPC without charge, but are not authorized
+ * to license or distribute it to anyone else except as part of a product or
+ * program developed by the user.
+ * 
+ * SUN RPC IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING THE
+ * WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
+ * 
+ * Sun RPC is provided with no support and without any obligation on the
+ * part of Sun Microsystems, Inc. to assist in its use, correction,
+ * modification or enhancement.
+ * 
+ * SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
+ * INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY SUN RPC
+ * OR ANY PART THEREOF.
+ * 
+ * In no event will Sun Microsystems, Inc. be liable for any lost revenue
+ * or profits or other special, indirect and consequential damages, even if
+ * Sun has been advised of the possibility of such damages.
+ * 
+ * Sun Microsystems, Inc.
+ * 2550 Garcia Avenue
+ * Mountain View, California  94043
+ */
+
+/*
+ * pmap_prot.h
+ * Protocol for the local binder service, or pmap.
+ *
+ * Copyright (C) 1984, Sun Microsystems, Inc.
+ *
+ * The following procedures are supported by the protocol:
+ *
+ * PMAPPROC_NULL() returns ()
+ * 	takes nothing, returns nothing
+ *
+ * PMAPPROC_SET(struct pmap) returns (bool_t)
+ * 	TRUE is success, FALSE is failure.  Registers the tuple
+ *	[prog, vers, prot, port].
+ *
+ * PMAPPROC_UNSET(struct pmap) returns (bool_t)
+ *	TRUE is success, FALSE is failure.  Un-registers pair
+ *	[prog, vers].  prot and port are ignored.
+ *
+ * PMAPPROC_GETPORT(struct pmap) returns (long unsigned).
+ *	0 is failure.  Otherwise returns the port number where the pair
+ *	[prog, vers] is registered.  It may lie!
+ *
+ * PMAPPROC_DUMP() RETURNS (struct pmaplist *)
+ *
+ * PMAPPROC_CALLIT(unsigned, unsigned, unsigned, string<>)
+ * 	RETURNS (port, string<>);
+ * usage: encapsulatedresults = PMAPPROC_CALLIT(prog, vers, proc, encapsulatedargs);
+ * 	Calls the procedure on the local machine.  If it is not registered,
+ *	this procedure is quite; ie it does not return error information!!!
+ *	This procedure only is supported on rpc/udp and calls via
+ *	rpc/udp.  This routine only passes null authentication parameters.
+ *	This file has no interface to xdr routines for PMAPPROC_CALLIT.
+ *
+ * The service supports remote procedure calls on udp/ip or tcp/ip socket 111.
+ */
+#ifndef __PMAP_PRO_HEADER__
+#define __PMAP_PRO_HEADER__
+
+#include <rpc/types.h>
+
+#define PMAPPORT		((u_short)111)
+#define PMAPPROG		((u_long)100000)
+#define PMAPVERS		((u_long)2)
+#define PMAPVERS_PROTO		((u_long)2)
+#define PMAPVERS_ORIG		((u_long)1)
+#define PMAPPROC_NULL		((u_long)0)
+#define PMAPPROC_SET		((u_long)1)
+#define PMAPPROC_UNSET		((u_long)2)
+#define PMAPPROC_GETPORT	((u_long)3)
+#define PMAPPROC_DUMP		((u_long)4)
+#define PMAPPROC_CALLIT		((u_long)5)
+
+struct pmap {
+	long unsigned pm_prog;
+	long unsigned pm_vers;
+	long unsigned pm_prot;
+	long unsigned pm_port;
+};
+
+ONCRPCAPI bool_t xdr_pmap();
+
+struct pmaplist {
+	struct pmap	pml_map;
+	struct pmaplist *pml_next;
+};
+
+ONCRPCAPI bool_t xdr_pmaplist();
+
+#endif //__PMAP_PRO_HEADER__

--- a/win32/include/rpc/rpc.h
+++ b/win32/include/rpc/rpc.h
@@ -1,0 +1,126 @@
+/**********************************************************************
+ * ONC RPC for WIN32.
+ * 1997 by WD Klotz
+ * ESRF, BP 220, F-38640 Grenoble, CEDEX
+ * klotz-tech@esrf.fr
+ *
+ * SUN's ONC RPC for Windows NT and Windows 95. Ammended port from
+ * Martin F.Gergeleit's distribution. This version has been modified
+ * and cleaned, such as to be compatible with Windows NT and Windows 95. 
+ * Compiler: MSVC++ version 4.2 and 5.0.
+ *
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ **********************************************************************/
+/*********************************************************************
+ * RPC for the Windows NT Operating System
+ * 1993 by Martin F. Gergeleit
+ * Users may use, copy or modify Sun RPC for the Windows NT Operating 
+ * System according to the Sun copyright below.
+ *
+ * RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+ * WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+ * USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+ *********************************************************************/
+
+/* @(#)rpc.h	2.3 88/08/10 4.0 RPCSRC; from 1.9 88/02/08 SMI */
+/*
+ * Sun RPC is a product of Sun Microsystems, Inc. and is provided for
+ * unrestricted use provided that this legend is included on all tape
+ * media and as a part of the software program in whole or part.  Users
+ * may copy or modify Sun RPC without charge, but are not authorized
+ * to license or distribute it to anyone else except as part of a product or
+ * program developed by the user.
+ *
+ * SUN RPC IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING THE
+ * WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
+ *
+ * Sun RPC is provided with no support and without any obligation on the
+ * part of Sun Microsystems, Inc. to assist in its use, correction,
+ * modification or enhancement.
+ *
+ * SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
+ * INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY SUN RPC
+ * OR ANY PART THEREOF.
+ *
+ * In no event will Sun Microsystems, Inc. be liable for any lost revenue
+ * or profits or other special, indirect and consequential damages, even if
+ * Sun has been advised of the possibility of such damages.
+ *
+ * Sun Microsystems, Inc.
+ * 2550 Garcia Avenue
+ * Mountain View, California  94043
+ */
+
+/*
+ * rpc.h, Just includes the billions of rpc header files necessary to
+ * do remote procedure calling.
+ *
+ * Copyright (C) 1984, Sun Microsystems, Inc.
+ */
+#ifndef __RPC_HEADER__
+#define __RPC_HEADER__
+
+#ifdef WIN32
+//#define FD_SETSIZE	128
+
+#include <stdlib.h>
+#include <winsock2.h>
+#include <windows.h>
+#include <rpc/types.h>		/* some typedefs */
+#include <process.h>
+#include <rpc/bcopy.h>
+
+#define WSAerrno (WSAGetLastError())
+#define gettimeofday(tv,tz) ((tv)->tv_sec = time(0), (tv)->tv_usec = 0)
+
+/* external data representation interfaces */
+#include <rpc/xdr.h>		/* generic (de)serializer */
+
+/* Client side only authentication */
+#include <rpc/auth.h>		/* generic authenticator (client side) */
+
+ONCRPCAPI int rpc_nt_init(void);
+ONCRPCAPI int rpc_nt_exit(void);
+ONCRPCAPI void nt_rpc_report(LPTSTR lpszMsg);
+ONCRPCAPI int xdr_opaque_auth(XDR *xdrs,
+                              struct opaque_auth *ap);
+
+#else  /* not WIN32 */ 
+#include <rpc/types.h>		/* some typedefs */
+#include <netinet/in.h>
+#endif
+
+/* Client side (mostly) remote procedure call */
+#include <rpc/clnt.h>		/* generic rpc stuff */
+
+/* semi-private protocol headers */
+#include <rpc/rpc_msg.h>	/* protocol for rpc messages */
+#ifdef WIN32
+#include <rpc/auth_uni.h>	/* protocol for unix style cred */
+#else
+#include <rpc/auth_unix.h>	/* protocol for unix style cred */
+#endif
+/*
+ *  Uncomment-out the next line if you are building the rpc library with
+ *  DES Authentication (see the README file in the secure_rpc/ directory).
+ */
+/*#include <rpc/auth_des.h>	/* protocol for des style cred */
+
+/* Server side only remote procedure callee */
+#include <rpc/svc.h>		/* service manager and multiplexer */
+#include <rpc/svc_auth.h>	/* service side authenticator */
+
+/*
+ * COMMENT OUT THE NEXT INCLUDE IF RUNNING ON SUN OS OR ON A VERSION
+ * OF UNIX BASED ON NFSSRC.  These systems will already have the structures
+ * defined by <rpc/netdb.h> included in <netdb.h>.
+ */
+/* routines for parsing /etc/rpc */
+#include <rpc/netdb.h>		/* structures and routines to parse /etc/rpc */
+
+#endif /* ndef __RPC_HEADER__ */

--- a/win32/librpc/Clnt_per.c
+++ b/win32/librpc/Clnt_per.c
@@ -257,9 +257,11 @@ void clnt_perrno(enum clnt_stat num)
 
 char *clnt_spcreateerror(char *s)
 {
-	extern int sys_nerr;
 #ifndef WIN32
 	extern char *sys_errlist[];
+	extern int sys_nerr;
+#else
+	extern __declspec(dllimport) int sys_nerr;
 #endif
 	char *str = _buf();
 

--- a/win32/librpc/Getrpcen.c
+++ b/win32/librpc/Getrpcen.c
@@ -79,8 +79,9 @@ struct rpcdata {
 	struct	rpcent rpc;
 	char	line[BUFSIZ+1];
 	char	*domain;
-} *rpcdata, *_rpcdata();
+} *rpcdata;
 
+static struct rpcdata *_rpcdata();
 static	struct rpcent *interpret();
 struct	hostent *gethostent();
 #ifdef WIN32

--- a/win32/librpc/Pmap_rmt.c
+++ b/win32/librpc/Pmap_rmt.c
@@ -223,7 +223,6 @@ static int getbroadcastnets(struct in_addr *addrs, SOCKET sock, char *buf)
 #endif
 }
 
-typedef bool_t (*resultproc_t)();
 
 enum clnt_stat
 clnt_broadcast(

--- a/win32/librpc/Xdr.c
+++ b/win32/librpc/Xdr.c
@@ -368,7 +368,7 @@ bool_t xdr_enum(XDR *xdrs, enum_t *ep)
 bool_t xdr_opaque(XDR *xdrs,	caddr_t cp,	u_int cnt)
 {
 	u_int rndup;
-	static crud[BYTES_PER_XDR_UNIT];
+	static int crud[BYTES_PER_XDR_UNIT];
 
 	/*
 	 * if no data we are done

--- a/win32/librpc/makefile.mingw
+++ b/win32/librpc/makefile.mingw
@@ -1,0 +1,47 @@
+MINGW=i686-w64-mingw32
+CC=$(MINGW)-gcc
+CFLAGS=-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero
+
+AR=$(MINGW)-ar
+
+LDFLAGS=-lwsock32 -ladvapi32
+# Remove the -Wpointer-to-int-cast. This old code is full of them
+# TODO: clean all this mess: 
+CFLAGS+=-Wno-pointer-to-int-cast
+
+# If the rpc include directory is not included in the standard path
+# you have to give the path to it here.
+RPCINCLUDEPATH=../include
+
+SRC= Auth_non.c Auth_uni.c authunix.c bcopy.c Bindresv.c clnt_gen.c Clnt_per.c clnt_raw.c clnt_sim.c Clnt_tcp.c Clnt_udp.c Get_myad.c Getrpcen.c Getrpcpo.c nt.c Pmap_cln.c pmap_get.c pmap_gma.c pmap_pr.c pmap_pro.c Pmap_rmt.c rpc_call.c rpc_comm.c rpc_prot.c svc_auth.c Svc_autu.c Svc.c svc_raw.c Svc_run.c Svc_simp.c Svc_tcp.c Svc_udp.c Xdr_arra.c Xdr.c xdr_floa.c xdr_mem.c Xdr_rec.c Xdr_refe.c xdr_stdi.c Xdr_strarr.c
+ 
+OBJS=$(patsubst %.c, %.o, $(SRC))
+
+DEFINITION =    oncrpc.def
+
+# If the rpc library is not included in the standard lib path
+# you have to give the path to it here.
+RPCLIBPATH = ../bin/
+
+all: oncrpc.dll portmap.exe
+
+clean:
+	rm -f $(OBJS) oncrpc.lib oncrpc.dll oncrpc.exp portmap.obj portmap.exe ../rpcgen/oncrpc.dll
+
+portmap.exe:	oncrpc.lib portmap.c
+	$(CC) -I$(RPCINCLUDEPATH) -c -DONCRPCDLL $(CFLAGS) $(CVARSDLL) portmap.c
+	$(CC) -static -o portmap.exe portmap.o $(RPCLIBPATH)oncrpc.lib -lwsock32
+	cp portmap.exe ../bin/pm_ascii.exe
+
+oncrpc.lib: objs
+	$(AR) rcs oncrpc.lib  $(OBJS)
+
+oncrpc.dll: objs oncrpc.lib
+	$(CC) -shared -o oncrpc.dll -Wl,--output-def $(DEFINITION) $(OBJS) $(LDFLAGS)
+	mkdir -p ../bin
+	cp oncrpc.lib ../bin
+	cp oncrpc.dll ../bin
+	cp oncrpc.dll ../rpcgen
+
+objs:
+	$(CC) -I$(RPCINCLUDEPATH) -c -DONCRPCDLL $(CFLAGS) $(CVARSDLL) $(SRC)

--- a/win32/librpc/makefile.mingw
+++ b/win32/librpc/makefile.mingw
@@ -1,4 +1,3 @@
-MINGW=i686-w64-mingw32
 CC=$(MINGW)-gcc
 CFLAGS=-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero
 
@@ -29,7 +28,7 @@ clean:
 	rm -f $(OBJS) oncrpc.lib oncrpc.dll oncrpc.exp portmap.obj portmap.exe ../rpcgen/oncrpc.dll
 
 portmap.exe:	oncrpc.lib portmap.c
-	$(CC) -I$(RPCINCLUDEPATH) -c -DONCRPCDLL $(CFLAGS) $(CVARSDLL) portmap.c
+	$(CC) -I$(RPCINCLUDEPATH) -c -DONCRPC_STATIC $(CFLAGS) $(CVARSDLL) portmap.c
 	$(CC) -static -o portmap.exe portmap.o $(RPCLIBPATH)oncrpc.lib -lwsock32
 	cp portmap.exe ../bin/pm_ascii.exe
 
@@ -44,4 +43,4 @@ oncrpc.dll: objs oncrpc.lib
 	cp oncrpc.dll ../rpcgen
 
 objs:
-	$(CC) -I$(RPCINCLUDEPATH) -c -DONCRPCDLL $(CFLAGS) $(CVARSDLL) $(SRC)
+	$(CC) -I$(RPCINCLUDEPATH) -c -DONCRPC_STATIC $(CFLAGS) $(CVARSDLL) $(SRC)

--- a/win32/librpc/makefile.visual
+++ b/win32/librpc/makefile.visual
@@ -1,0 +1,73 @@
+# Nmake macros for building Windows 32-Bit apps
+!include <ntwin32.mak>
+
+# If the rpc include directory is not included in the standard path
+# you have to give the path to it here.
+RPCINCLUDEPATH = ..\include
+
+# If the rpc library is not included in the standard lib path
+# you have to give the path to it here.
+RPCLIBPATH = ..\bin\\
+
+DEFINITION =	ONCRPC.DEF
+
+OBJS =		CLNT_RAW.OBJ \
+		XDR.OBJ \
+		CLNT_TCP.OBJ \
+		CLNT_UDP.OBJ \
+		PMAP_RMT.OBJ \
+		RPC_PROT.OBJ \
+		SVC_AUTU.OBJ \
+		SVC_AUTH.OBJ \
+		SVC_RAW.OBJ \
+		SVC_RUN.OBJ \
+		SVC_TCP.OBJ \
+		SVC_UDP.OBJ \
+		XDR_MEM.OBJ \
+		XDR_REC.OBJ \
+		AUTH_NON.OBJ \
+		AUTH_UNI.OBJ \
+		AUTHUNIX.OBJ \
+		BINDRESV.OBJ \
+		CLNT_GEN.OBJ \
+		CLNT_PER.OBJ \
+		CLNT_SIM.OBJ \
+		GET_MYAD.OBJ \
+		GETRPCEN.OBJ \
+		GETRPCPO.OBJ \
+		PMAP_CLN.OBJ \
+		PMAP_GET.OBJ \
+		PMAP_GMA.OBJ \
+		PMAP_PRO.OBJ \
+		PMAP_PR.OBJ \
+		RPC_CALL.OBJ \
+		RPC_COMM.OBJ \
+		SVC_SIMP.OBJ \
+		XDR_ARRA.OBJ \
+		XDR_FLOA.OBJ \
+		XDR_REFE.OBJ \
+		XDR_STDI.OBJ \
+		SVC.OBJ \
+		BCOPY.OBJ \
+		NT.OBJ
+
+all: oncrpc.dll portmap.exe
+
+clean:
+	del $(OBJS) oncrpc.lib oncrpc.dll oncrpc.exp portmap.obj portmap.exe ..\rpcgen\oncrpc.dll
+
+portmap.exe:	oncrpc.lib portmap.obj
+     $(link) $(conlflags) $(ldebug) -out:portmap.exe PORTMAP.obj $(RPCLIBPATH)oncrpc.lib $(conlibsdll) wsock32.lib
+	copy portmap.exe ..\bin\pm_ascii.exe
+
+oncrpc.lib:	$(OBJS) oncrpc.def
+    $(implib) /out:oncrpc.lib /def:$(DEFINITION) $(OBJS)
+
+oncrpc.dll:	$(OBJS) oncrpc.lib oncrpc.exp
+    $(link) /DLL /out:oncrpc.dll -entry:_DllMainCRTStartup$(DLLENTRY) $(ldebug) oncrpc.exp $(OBJS) $(conlibsdll) wsock32.lib advapi32.lib
+    copy oncrpc.lib ..\bin
+    copy oncrpc.dll ..\bin
+    copy oncrpc.dll ..\rpcgen
+
+.c.obj:
+    $(cc) /I$(RPCINCLUDEPATH) /DONCRPCDLL $(cdebug) $(cflags) $(cvarsdll) $*.c

--- a/win32/librpc/oncrpc.def
+++ b/win32/librpc/oncrpc.def
@@ -1,95 +1,99 @@
-LIBRARY oncrpc
 EXPORTS
-authnone_create
-authunix_create
-authunix_create_default
-bcopy
-bzero
-bcmp
-clnt_create
-clnt_broadcast
-clnt_pcreateerror
-clnt_perrno
-clnt_perror
-clnt_spcreateerror
-clnt_sperrno
-clnt_sperror
-clntraw_create
-clnttcp_create
-clntudp_bufcreate
-clntudp_create
-get_myaddress
-getrpcbyname
-getrpcbynumber
-pmap_getmaps
-pmap_getport
-pmap_set
-pmap_unset
-rpc_nt_exit
-rpc_nt_init
-svc_getreq
-svc_getreqset
-svc_register
-svc_run
-svc_sendreply
-svc_unregister
-svcerr_auth
-svcerr_decode
-svcerr_noproc
-svcerr_noprog
-svcerr_progvers
-svcerr_systemerr
-svcerr_weakauth
-svcraw_create
-svctcp_create
-svcudp_bufcreate
-svcudp_create
-xdr_array
-xdr_authunix_parms
-xdr_bool
-xdr_bytes
-xdr_callhdr
-xdr_callmsg
-xdr_char
-xdr_des_block
-xdr_double
-xdr_enum
-xdr_float
-xdr_free
-xdr_hyper
-xdr_int32_t
-xdr_uint32_t
-xdr_int64_t
-xdr_uint64_t
-xdr_int
-xdr_long
-xdr_netobj
-xdr_opaque
-xdr_opaque_auth
-xdr_pmap
-xdr_pmaplist
-xdr_pointer
-xdr_reference
-xdr_replymsg
-xdr_short
-xdr_string
-xdr_u_char
-xdr_u_int
-xdr_u_hyper
-xdr_u_long
-xdr_u_short
-xdr_union
-xdr_vector
-xdr_void
-xdr_wrapstring
-xdrmem_create
-xdrrec_create
-xdrrec_endofrecord
-xdrrec_eof
-xdrrec_skiprecord
-xdrstdio_create
-xprt_register
-xprt_unregister
-svc_fdset DATA
-rpc_createerr DATA
-_null_auth DATA
+    _null_auth @1 DATA
+    authnone_create @2
+    authunix_create @3
+    authunix_create_default @4
+    bcmp @5
+    bcopy @6
+    bzero @7
+    clnt_broadcast @8
+    clnt_create @9
+    clnt_pcreateerror @10
+    clnt_perrno @11
+    clnt_perror @12
+    clnt_spcreateerror @13
+    clnt_sperrno @14
+    clnt_sperror @15
+    clntraw_create @16
+    clnttcp_create @17
+    clntudp_bufcreate @18
+    clntudp_create @19
+    get_myaddress @20
+    getrpcbyname @21
+    getrpcbynumber @22
+    getrpcent @23
+    nt_rpc_report @24
+    pmap_getmaps @25
+    pmap_getport @26
+    pmap_rmtcall @27
+    pmap_set @28
+    pmap_unset @29
+    rpc_nt_exit @30
+    rpc_nt_init @31
+    svc_getreq @32
+    svc_getreqset @33
+    svc_register @34
+    svc_run @35
+    svc_sendreply @36
+    svc_unregister @37
+    svcerr_auth @38
+    svcerr_decode @39
+    svcerr_noproc @40
+    svcerr_noprog @41
+    svcerr_progvers @42
+    svcerr_systemerr @43
+    svcerr_weakauth @44
+    svcraw_create @45
+    svctcp_create @46
+    svcudp_bufcreate @47
+    svcudp_create @48
+    xdr_array @49
+    xdr_authunix_parms @50
+    xdr_bool @51
+    xdr_bytes @52
+    xdr_callhdr @53
+    xdr_callmsg @54
+    xdr_char @55
+    xdr_des_block @56
+    xdr_double @57
+    xdr_enum @58
+    xdr_float @59
+    xdr_free @60
+    xdr_hyper @61
+    xdr_int @62
+    xdr_int32_t @63
+    xdr_int64_t @64
+    xdr_long @65
+    xdr_netobj @66
+    xdr_opaque @67
+    xdr_opaque_auth @68
+    xdr_pmap @69
+    xdr_pmaplist @70
+    xdr_pointer @71
+    xdr_quad_t @72
+    xdr_reference @73
+    xdr_replymsg @74
+    xdr_rmtcall_args @75
+    xdr_rmtcallres @76
+    xdr_short @77
+    xdr_strarray @78
+    xdr_string @79
+    xdr_u_char @80
+    xdr_u_hyper @81
+    xdr_u_int @82
+    xdr_u_long @83
+    xdr_u_short @84
+    xdr_uint32_t @85
+    xdr_uint64_t @86
+    xdr_union @87
+    xdr_vector @88
+    xdr_void @89
+    xdr_wrapstring @90
+    xdrmem_create @91
+    xdrrec_create @92
+    xdrrec_endofrecord @93
+    xdrrec_eof @94
+    xdrrec_skiprecord @95
+    xdrstdio_create @96
+    xprt_register @97
+    xprt_unregister @98

--- a/win32/rpcgen/makefile.mingw
+++ b/win32/rpcgen/makefile.mingw
@@ -1,4 +1,3 @@
-MINGW=i686-w64-mingw32
 CC=$(MINGW)-gcc
 CFLAGS=-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero
 
@@ -23,4 +22,4 @@ clean:
 	rm -f $(GOAL) $(OBJS)
 
 objs:
-	$(CC) -DONCRPCDLL -c -I$(RPCINCLUDEPATH) $(CFLAGS) $(SRC)
+	$(CC) -DONCRPC_STATIC -c -I$(RPCINCLUDEPATH) $(CFLAGS) $(SRC)

--- a/win32/rpcgen/makefile.mingw
+++ b/win32/rpcgen/makefile.mingw
@@ -1,0 +1,26 @@
+MINGW=i686-w64-mingw32
+CC=$(MINGW)-gcc
+CFLAGS=-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero
+
+# If the rpc include directory is not included in the standard path
+# you have to give the path to it here.
+RPCINCLUDEPATH=../include
+
+# If the rpc library is not included in the standard lib path
+# you have to give the path to it here.
+RPCLIBPATH= ../bin
+
+SRC= rpc_main.c rpc_hout.c rpc_cout.c rpc_pars.c rpc_scan.c rpc_util.c rpc_svco.c rpc_clnt.c
+OBJS=$(patsubst %.c, %.o, $(SRC))
+ 
+GOAL=rpcgen.exe
+
+$(GOAL): objs $(OBJS) $(RPCLIBPATH)/oncrpc.lib
+	$(CC) -o $(GOAL) $(OBJS) $(RPCLIBPATH)/oncrpc.lib
+	cp $(GOAL) ../bin
+
+clean:
+	rm -f $(GOAL) $(OBJS)
+
+objs:
+	$(CC) -DONCRPCDLL -c -I$(RPCINCLUDEPATH) $(CFLAGS) $(SRC)

--- a/win32/rpcgen/makefile.visual
+++ b/win32/rpcgen/makefile.visual
@@ -1,0 +1,68 @@
+#**********************************************************************
+#* ONC RPC for WIN32.
+#* 1997 by WD Klotz
+#* ESRF, BP 220, F-38640 Grenoble, CEDEX
+#* klotz-tech@esrf.fr
+#*
+#* SUN's ONC RPC for Windows NT and Windows 95. Ammended port from
+#* Martin F.Gergeleit's distribution. This version has been modified
+#* and cleaned, such as to be compatible with Windows NT and Windows 95. 
+#* Compiler: MSVC++ version 4.2 and 5.0.
+#*
+#* RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+#* WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+#* USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+#**********************************************************************
+# Nmake macros for building Windows 32-Bit apps
+!include <ntwin32.mak>
+
+# If the rpc include directory is not included in the standard path
+# you have to give the path to it here.
+RPCINCLUDEPATH = ..
+
+# If the rpc library is not included in the standard lib path
+# you have to give the path to it here.
+RPCLIBPATH = ..\bin\\
+
+OBJS= rpc_main.obj rpc_hout.obj rpc_cout.obj rpc_pars.obj rpc_scan.obj rpc_util.obj \
+	rpc_svco.obj rpc_clnt.obj
+
+GOAL=rpcgen.exe
+
+$(GOAL): $(OBJS) $(RPCLIBPATH)\oncrpc.lib
+	$(link) $(ldebug) $(conflags) $(OBJS) -out:$(GOAL) $(conlibsdll) $(RPCLIBPATH)\oncrpc.lib
+	copy $(GOAL) ..\bin
+
+clean:
+	-del $(GOAL) $(OBJS)
+
+.c.obj:
+    $(cc) /I$(RPCINCLUDEPATH) $(cdebug) $(cflags) $(cvarsdll) $*.c
+
+rpc_main.obj: rpc_main.c
+rpc_main.obj: .\rpc_util.h
+rpc_main.obj: .\rpc_pars.h
+rpc_main.obj: .\rpc_scan.h
+rpc_hout.obj: rpc_hout.c
+rpc_hout.obj: .\rpc_util.h
+rpc_hout.obj: .\rpc_pars.h
+rpc_cout.obj: rpc_cout.c
+rpc_cout.obj: .\rpc_util.h
+rpc_cout.obj: .\rpc_pars.h
+rpc_pars.obj: rpc_pars.c
+rpc_pars.obj: .\rpc_util.h
+rpc_pars.obj: .\rpc_scan.h
+rpc_pars.obj: .\rpc_pars.h
+rpc_scan.obj: rpc_scan.c
+rpc_scan.obj: .\rpc_scan.h
+rpc_scan.obj: .\rpc_util.h
+rpc_util.obj: rpc_util.c
+rpc_util.obj: .\rpc_scan.h
+rpc_util.obj: .\rpc_pars.h
+rpc_util.obj: .\rpc_util.h
+rpc_svco.obj: rpc_svco.c
+rpc_svco.obj: .\rpc_pars.h
+rpc_svco.obj: .\rpc_util.h
+rpc_clnt.obj: rpc_clnt.c
+rpc_clnt.obj: .\rpc_pars.h
+rpc_clnt.obj: .\rpc_util.h

--- a/win32/rpcgen/rpc_main.c
+++ b/win32/rpcgen/rpc_main.c
@@ -86,16 +86,6 @@ static char sccsid[] = "@(#)rpc_main.c 1.7 87/06/24 (C) 1987 SMI";
 
 #define EXTEND	1		/* alias for TRUE */
 
-struct commandline {
-	int cflag;
-	int hflag;
-	int lflag;
-	int sflag;
-	int mflag;
-	char *infile;
-	char *outfile;
-};
-
 static char *cmdname;
 #ifdef WIN32
 #ifdef __BORLANDC__

--- a/win32/rpcgen/rpc_main.h
+++ b/win32/rpcgen/rpc_main.h
@@ -1,6 +1,16 @@
 #ifndef __RPC_MAIN_HEADER__
 #define __RPC_MAIN_HEADER__
 
+struct commandline {
+        int cflag;
+        int hflag;
+        int lflag;
+        int sflag;
+        int mflag;
+        char *infile;
+        char *outfile;
+};
+
 static char *extendfile(char *file, char *ext);
 static void open_output(char *infile, char*outfile);
 static void open_input(char *infile, char *define);

--- a/win32/rpcinfo/makefile.mingw
+++ b/win32/rpcinfo/makefile.mingw
@@ -1,4 +1,3 @@
-MINGW=i686-w64-mingw32
 CC=$(MINGW)-gcc
 CFLAGS=-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero
 
@@ -23,5 +22,5 @@ clean:
 	rm -f $(GOAL) $(OBJS)
 
 objs:
-	$(CC) -DONCRPCDLL -c -I$(RPCINCLUDEPATH) $(CFLAGS) $(SRC)
+	$(CC) -DONCRPC_STATIC -c -I$(RPCINCLUDEPATH) $(CFLAGS) $(SRC)
 

--- a/win32/rpcinfo/makefile.mingw
+++ b/win32/rpcinfo/makefile.mingw
@@ -1,0 +1,27 @@
+MINGW=i686-w64-mingw32
+CC=$(MINGW)-gcc
+CFLAGS=-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero
+
+# If the rpc include directory is not included in the standard path
+# you have to give the path to it here.
+RPCINCLUDEPATH=../include
+
+# If the rpc library is not included in the standard lib path
+# you have to give the path to it here.
+RPCLIBPATH =../bin
+
+SRC= rpcinfo.c
+OBJS=$(patsubst %.c, %.o, $(SRC))
+
+GOAL=rpcinfo.exe
+
+$(GOAL): objs $(OBJS) $(RPCLIBPATH)/oncrpc.lib
+	$(CC) -o $(GOAL) $(OBJS) $(RPCLIBPATH)/oncrpc.lib -lwsock32
+	cp $(GOAL) ../bin
+
+clean:
+	rm -f $(GOAL) $(OBJS)
+
+objs:
+	$(CC) -DONCRPCDLL -c -I$(RPCINCLUDEPATH) $(CFLAGS) $(SRC)
+

--- a/win32/rpcinfo/makefile.visual
+++ b/win32/rpcinfo/makefile.visual
@@ -1,0 +1,42 @@
+#**********************************************************************
+#* ONC RPC for WIN32.
+#* 1997 by WD Klotz
+#* ESRF, BP 220, F-38640 Grenoble, CEDEX
+#* klotz-tech@esrf.fr
+#*
+#* SUN's ONC RPC for Windows NT and Windows 95. Ammended port from
+#* Martin F.Gergeleit's distribution. This version has been modified
+#* and cleaned, such as to be compatible with Windows NT and Windows 95. 
+#* Compiler: MSVC++ version 4.2 and 5.0.
+#*
+#* RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+#* WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+#* USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+#**********************************************************************
+# Nmake macros for building Windows 32-Bit apps
+!include <ntwin32.mak>
+
+# If the rpc include directory is not included in the standard path
+# you have to give the path to it here.
+RPCINCLUDEPATH = ..\include
+
+# If the rpc library is not included in the standard lib path
+# you have to give the path to it here.
+RPCLIBPATH = ..\librpc\lib\release\\
+
+OBJS= rpcinfo.obj
+
+GOAL=rpcinfo.exe
+
+$(GOAL): $(OBJS) $(RPCLIBPATH)\oncrpc.lib
+	$(link) $(ldebug) $(conflags) $(OBJS) -out:$(GOAL) $(conlibsdll) $(RPCLIBPATH)\oncrpc.lib wsock32.lib
+	copy $(GOAL) ..\bin
+
+clean:
+	-del $(GOAL) $(OBJS)
+
+.c.obj:
+    $(cc) /I$(RPCINCLUDEPATH) $(cdebug) $(cflags) $(cvarsdll) $*.c
+
+rpcinfo.obj: rpcinfo.c getopt.c
+

--- a/win32/service/makefile.mingw
+++ b/win32/service/makefile.mingw
@@ -1,4 +1,3 @@
-MINGW=i686-w64-mingw32
 CC=$(MINGW)-gcc
 CFLAGS=-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero
 
@@ -21,10 +20,10 @@ clean:
 	rm -f *.o *.exe	
 
 portmap.exe: service.c portmap.c $(RPCLIBPATH)/oncrpc.lib
-	$(CC) -I$(RPCINCLUDEPATH) -D$(OS) -DONCRPCDLL $(CFLAGS) -o portmap.exe portmap.c service.c $(RPCLIBPATH)/oncrpc.lib -lwsock32 -ladvapi32 -luser32
+	$(CC) -I$(RPCINCLUDEPATH) -D$(OS) -DONCRPC_STATIC $(CFLAGS) -o portmap.exe portmap.c service.c $(RPCLIBPATH)/oncrpc.lib -lwsock32 -ladvapi32 -luser32
 	cp portmap.exe ../bin/
 
 inst_pm.exe: inst_pm.c
-	$(CC) -I$(RPCINCLUDEPATH) -D$(OS) -DONCRPCDLL $(CFLAGS) -o inst_pm.exe inst_pm.c -ladvapi32 -luser32
+	$(CC) -I$(RPCINCLUDEPATH) -D$(OS) -DONCRPC_STATIC $(CFLAGS) -o inst_pm.exe inst_pm.c -ladvapi32 -luser32
 	cp inst_pm.exe ../bin
 

--- a/win32/service/makefile.mingw
+++ b/win32/service/makefile.mingw
@@ -1,0 +1,30 @@
+MINGW=i686-w64-mingw32
+CC=$(MINGW)-gcc
+CFLAGS=-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero
+
+RPCINCLUDEPATH=../include
+
+# If the rpc library is not included in the standard lib path
+# you have to give the path to it here.
+RPCLIBPATH=../bin
+
+# If you are on Windows NT uncomment the next line
+OS=_NT
+
+# If you are on Windows 95 uncomment the next line
+#OS=_W95
+
+all: portmap.exe inst_pm.exe
+
+# Update the object file if necessary
+clean:
+	rm -f *.o *.exe	
+
+portmap.exe: service.c portmap.c $(RPCLIBPATH)/oncrpc.lib
+	$(CC) -I$(RPCINCLUDEPATH) -D$(OS) -DONCRPCDLL $(CFLAGS) -o portmap.exe portmap.c service.c $(RPCLIBPATH)/oncrpc.lib -lwsock32 -ladvapi32 -luser32
+	cp portmap.exe ../bin/
+
+inst_pm.exe: inst_pm.c
+	$(CC) -I$(RPCINCLUDEPATH) -D$(OS) -DONCRPCDLL $(CFLAGS) -o inst_pm.exe inst_pm.c -ladvapi32 -luser32
+	cp inst_pm.exe ../bin
+

--- a/win32/service/makefile.visual
+++ b/win32/service/makefile.visual
@@ -1,0 +1,51 @@
+#**********************************************************************
+#* ONC RPC for WIN32.
+#* 1997 by WD Klotz
+#* ESRF, BP 220, F-38640 Grenoble, CEDEX
+#* klotz-tech@esrf.fr
+#*
+#* SUN's ONC RPC for Windows NT and Windows 95. Ammended port from
+#* Martin F.Gergeleit's distribution. This version has been modified
+#* and cleaned, such as to be compatible with Windows NT and Windows 95. 
+#* Compiler: MSVC++ version 4.2 and 5.0.
+#*
+#* RPC for the Windows NT Operating System COMES WITH ABSOLUTELY NO 
+#* WARRANTY, NOR WILL I BE LIABLE FOR ANY DAMAGES INCURRED FROM THE 
+#* USE OF. USE ENTIRELY AT YOUR OWN RISK!!!
+#**********************************************************************
+!include <win32.mak>
+
+# If the rpc include directory is not included in the standard path
+# you have to give the path to it here.
+RPCINCLUDEPATH = ..\include
+
+# If the rpc library is not included in the standard lib path
+# you have to give the path to it here.
+RPCLIBPATH = ..\librpc\lib\oncrpc_static\Debug\
+
+# If you are on Windows NT uncomment the next line
+OS=_NT
+
+# If you are on Windows 95 uncomment the next line
+#OS=_W95
+
+all: portmap.exe
+
+#if you are on Windows NT uncomment the next line
+all: inst_pm.exe
+
+# Update the object file if necessary
+
+clean:
+    del *.obj *.exe
+
+portmap.exe: service.obj portmap.obj $(RPCLIBPATH)\oncrpc.lib
+    $(link) $(ldebug) $(conflags) -out:portmap.exe portmap.obj service.obj $(conlibs) $(RPCLIBPATH)\oncrpc.lib wsock32.lib  advapi32.lib user32.lib
+    copy portmap.exe ..\bin
+
+inst_pm.exe: inst_pm.obj
+    $(link) $(ldebug) $(conflags) -out:inst_pm.exe inst_pm.obj $(conlibs) advapi32.lib user32.lib
+    copy inst_pm.exe ..\bin
+
+.c.obj:
+    $(cc) /I$(RPCINCLUDEPATH) -D$(OS) $(cdebug) $(cflags) $(cvars) $*.c


### PR DESCRIPTION
First attempt to create a MinGW Win32 cross-compilation target for the oncrpc-win32 lib. The pull request includes commits that mainly focus on:
1) Migrating the original oncrpc-win32 nmake file to GNU makefiles
2) Adapting some headers and .c files (minor patches) so that some serious compilation warnings are fixed.

The makefile present in the project root directory will compile both the 32 and 64 bits static and dynamic  libraries (as well as the companion .exe files). This makefile expects both i686-w64-mingw32 and x86_64-w64-mingw32 to be installed on the system (this is a limitation to be fixed in future commits). Invoke with:
$ make -f makefile.mingw

PS: though not tested, compatibility of the project with nmake and visual compilation targets should be preserved.